### PR TITLE
add jpeg quality options

### DIFF
--- a/uvtt2fgu.py
+++ b/uvtt2fgu.py
@@ -30,6 +30,9 @@ class ConfigFileData(object):
         self.xmlpath = None
         self.jpgpath = None
         self.writejpg = True
+        self.jpgQuality = 90
+        self.jpgOptimize = True
+        self.jpgSubsampling = 2
         self.pngpath = None
         self.writepng = True
         self.forceOverwrite = None
@@ -40,6 +43,9 @@ class ConfigFileData(object):
         for section in config.sections():
             self.xmlpath = config[section].get('xmlpath')
             self.jpgpath = config[section].get('jpgpath')
+            self.jpgQuality = config[section].get('jpgquality')
+            self.jpgOptimize = config[section].get('jpgoptimize')
+            self.jpgSubsampling = config[section].get('jpgsubsampling')
             self.writejpg = config[section].getboolean('writejpg', True)
             self.pngpath = config[section].get('pngpath')
             self.writepng = config[section].getboolean('writepng', True)
@@ -407,7 +413,11 @@ class UVTTFile(object):
         imagebytes = BytesIO(self.image)
         pngimage = Image.open(imagebytes)
         jpgimage = pngimage.convert('RGB')
-        jpgimage.save(filepath)
+        jpgimage.save(
+            filepath, 
+            quality=configData.jpgQuality, 
+            subsampling=configData.jpgSubsampling, 
+            optimize=configData.jpgOptimize)
 
     def writeXml(self, filepath: Path) -> None:
         '''Write out the FGU .xml file for line-of-sight and lighting'''


### PR DESCRIPTION
The default Pillow jpeg settings default to quality 75 and don't use the optimize setting. This PR adds the defaults

```
        self.jpgQuality = 90
        self.jpgOptimize = True
        self.jpgSubsampling = 2
```

which results in the following improvements:

**Original:**
![original](https://user-images.githubusercontent.com/578676/174425011-9978d327-c3e9-4ca5-8caa-825a4a104285.png)

**With higher quality settings:**
![higher quality](https://user-images.githubusercontent.com/578676/174425013-dae72634-2b1f-4740-8259-61f26be00526.png)

Obviously this does increase file sizes; so I've added this as configuration that can be overridden if the user wishes.